### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -501,8 +501,19 @@ module.exports.serveFrontend = async (event) => {
     console.log('Frontend handler - Requested path:', requestedPath);
 
     // Construct the full path to the file in the frontend build directory
-    const filePath = path.resolve(__dirname, '..', 'build', requestedPath);
+    const buildDir = path.resolve(__dirname, '..', 'build');
+    const filePath = path.resolve(buildDir, requestedPath);
     console.log('Frontend handler - File path:', filePath);
+
+    // Ensure the resolved filePath is within the build directory
+    if (!filePath.startsWith(buildDir)) {
+        console.error('Frontend handler - Attempted access outside build directory:', filePath);
+        return {
+            statusCode: 403,
+            headers: { 'Content-Type': 'text/html', 'Access-Control-Allow-Origin': '*' },
+            body: '<html><body><h1>403 Forbidden</h1><p>Access denied.</p></body></html>',
+        };
+    }
 
     try {
         if (fs.existsSync(filePath)) {


### PR DESCRIPTION
Potential fix for [https://github.com/logan-han/sms-otp-burner/security/code-scanning/5](https://github.com/logan-han/sms-otp-burner/security/code-scanning/5)

To fix the issue, we need to ensure that the resolved `filePath` is contained within the intended root directory (`build`). This can be achieved by:
1. Using `path.resolve` to normalize the path and remove any `../` sequences.
2. Verifying that the resolved `filePath` starts with the absolute path of the `build` directory.
3. If the resolved path does not start with the `build` directory, return an error response to prevent unauthorized access.

The changes will be made in the `serveFrontend` function in `src/handler.js`. Specifically:
- Add a check to ensure that `filePath` starts with the absolute path of the `build` directory.
- If the check fails, return a `403 Forbidden` response.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
