### PR TITLE
Migrate ESLint 8 → 9 with flat config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,33 +3,40 @@ import reactPlugin from "eslint-plugin-react";
 import reactHooksPlugin from "eslint-plugin-react-hooks";
 import globals from "globals";
 
+const reactBaseConfig = {
+  plugins: {
+    react: reactPlugin,
+    "react-hooks": reactHooksPlugin,
+  },
+  languageOptions: {
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
+  },
+  rules: {
+    ...reactPlugin.configs.recommended.rules,
+    ...reactHooksPlugin.configs.recommended.rules,
+    "react/react-in-jsx-scope": "off",
+  },
+  settings: {
+    react: { version: "detect" },
+  },
+};
+
 export default [
   js.configs.recommended,
 
   // React frontend files
   {
+    ...reactBaseConfig,
     files: ["src/**/*.js"],
     ignores: ["src/handler.js", "src/__tests__/**"],
-    plugins: {
-      react: reactPlugin,
-      "react-hooks": reactHooksPlugin,
-    },
     languageOptions: {
-      parserOptions: {
-        ecmaFeatures: { jsx: true },
-      },
+      ...reactBaseConfig.languageOptions,
       globals: {
         ...globals.browser,
         process: "readonly",
       },
-    },
-    rules: {
-      ...reactPlugin.configs.recommended.rules,
-      ...reactHooksPlugin.configs.recommended.rules,
-      "react/react-in-jsx-scope": "off",
-    },
-    settings: {
-      react: { version: "detect" },
     },
   },
 
@@ -62,30 +69,17 @@ export default [
 
   // Frontend test files (Browser + Jest + React)
   {
+    ...reactBaseConfig,
     files: ["src/__tests__/*.test.js"],
     ignores: ["src/__tests__/backend/**"],
-    plugins: {
-      react: reactPlugin,
-      "react-hooks": reactHooksPlugin,
-    },
     languageOptions: {
-      parserOptions: {
-        ecmaFeatures: { jsx: true },
-      },
+      ...reactBaseConfig.languageOptions,
       globals: {
         ...globals.browser,
         ...globals.jest,
         global: "readonly",
         process: "readonly",
       },
-    },
-    rules: {
-      ...reactPlugin.configs.recommended.rules,
-      ...reactHooksPlugin.configs.recommended.rules,
-      "react/react-in-jsx-scope": "off",
-    },
-    settings: {
-      react: { version: "detect" },
     },
   },
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,91 @@
+import js from "@eslint/js";
+import reactPlugin from "eslint-plugin-react";
+import reactHooksPlugin from "eslint-plugin-react-hooks";
+import globals from "globals";
+
+export default [
+  js.configs.recommended,
+
+  // React frontend files
+  {
+    files: ["src/**/*.js"],
+    ignores: ["src/handler.js", "src/__tests__/**"],
+    plugins: {
+      react: reactPlugin,
+      "react-hooks": reactHooksPlugin,
+    },
+    languageOptions: {
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+      globals: {
+        ...globals.browser,
+        process: "readonly",
+      },
+    },
+    rules: {
+      ...reactPlugin.configs.recommended.rules,
+      ...reactHooksPlugin.configs.recommended.rules,
+      "react/react-in-jsx-scope": "off",
+    },
+    settings: {
+      react: { version: "detect" },
+    },
+  },
+
+  // Backend handler (Node.js / CommonJS)
+  {
+    files: ["src/handler.js"],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+    rules: {
+      "no-console": "off",
+    },
+  },
+
+  // Backend tests and mocks (Node.js / CommonJS + Jest)
+  {
+    files: ["src/__tests__/backend/**/*.js", "src/__tests__/__mocks__/**/*.js"],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.jest,
+      },
+    },
+    rules: {
+      "no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    },
+  },
+
+  // Frontend test files (Browser + Jest + React)
+  {
+    files: ["src/__tests__/*.test.js"],
+    ignores: ["src/__tests__/backend/**"],
+    plugins: {
+      react: reactPlugin,
+      "react-hooks": reactHooksPlugin,
+    },
+    languageOptions: {
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+      globals: {
+        ...globals.browser,
+        ...globals.jest,
+        global: "readonly",
+        process: "readonly",
+      },
+    },
+    rules: {
+      ...reactPlugin.configs.recommended.rules,
+      ...reactHooksPlugin.configs.recommended.rules,
+      "react/react-in-jsx-scope": "off",
+    },
+    settings: {
+      react: { version: "detect" },
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start:backend": "export $(cat .env | xargs) && serverless offline start",
     "start:react": "react-scripts start",
-    "build:react": "react-scripts build",
+    "build:react": "DISABLE_ESLINT_PLUGIN=true react-scripts build",
     "test:frontend": "react-scripts test --testPathIgnorePatterns=src/__tests__/backend --testPathIgnorePatterns=src/__tests__/__mocks__",
     "test:backend": "jest --config=jest.backend.config.js",
     "test:ui": "playwright test",
@@ -31,22 +31,20 @@
     "web-vitals": "^5.1.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.0.0",
     "@playwright/test": "^1.49.1",
     "babel-jest": "^30.2.0",
-    "eslint": "^8.57.0",
     "concurrently": "^9.2.1",
+    "eslint": "^9.0.0",
+    "eslint-plugin-react": "^7.37.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "globals": "^16.0.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^30.2.0",
     "jest-transform-css": "^6.0.3",
     "serverless": "^4.27.0",
     "serverless-dotenv-plugin": "^6.0.0",
     "serverless-offline": "^14.4.0"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
   },
   "browserslist": {
     "production": [

--- a/src/App.js
+++ b/src/App.js
@@ -58,7 +58,7 @@ function App() {
     }
   }, []);
 
-  const fetchMessages = useCallback(async (subscriptionData = null) => {
+  const fetchMessages = useCallback(async () => {
     setError(null);
     try {
       const response = await fetch(`${API_BASE_URL}/messages`);

--- a/src/__tests__/backend/handler.test.js
+++ b/src/__tests__/backend/handler.test.js
@@ -81,7 +81,7 @@ describe('Handler Functions', () => {
       mockFetch.mockReset();
 
       // Mock successful auth token followed by API calls
-      mockFetch.mockImplementation((url, options) => {
+      mockFetch.mockImplementation((url, _options) => {
         if (url.includes('oauth/token')) {
           return Promise.resolve(createFetchResponse({
             access_token: 'test_access_token',
@@ -121,7 +121,7 @@ describe('Handler Functions', () => {
     });
 
     test('leaseNumber returns existing numbers when max count is reached', async () => {
-      mockFetch.mockImplementation((url, options) => {
+      mockFetch.mockImplementation((url, _options) => {
         if (url.includes('oauth/token')) {
           return Promise.resolve(createFetchResponse({
             access_token: 'test_access_token',

--- a/src/handler.js
+++ b/src/handler.js
@@ -294,8 +294,8 @@ module.exports.leaseNumber = async (event) => {
     try {
       existingNumbers = await fetchAllVirtualNumbers();
       log.info(`Found ${existingNumbers.length} existing virtual numbers`);
-    } catch {
-      log.warn('Error checking existing virtual numbers');
+    } catch (error) {
+      log.warn('Error checking existing virtual numbers', error);
     }
 
     const allExistingNumbers = existingNumbers.map(vn => vn.virtualNumber);

--- a/src/handler.js
+++ b/src/handler.js
@@ -294,7 +294,7 @@ module.exports.leaseNumber = async (event) => {
     try {
       existingNumbers = await fetchAllVirtualNumbers();
       log.info(`Found ${existingNumbers.length} existing virtual numbers`);
-    } catch (checkError) {
+    } catch {
       log.warn('Error checking existing virtual numbers');
     }
 


### PR DESCRIPTION
## Summary
- Migrates from ESLint 8 (eslintrc via `react-app`) to **ESLint 9** with flat config (`eslint.config.mjs`)
- ESLint 10 was originally planned (Dependabot PR #39) but `eslint-plugin-react` and `eslint-plugin-react-hooks` don't yet support it — ESLint 9 is the latest viable major version
- Adds `DISABLE_ESLINT_PLUGIN=true` to `build:react` script so `react-scripts` doesn't run its own incompatible ESLint internally (standalone `yarn lint` handles linting)
- Fixes unused variable lint errors caught by the new config

### New dependencies
- `@eslint/js` — ESLint recommended rules base
- `eslint-plugin-react` — React-specific lint rules
- `eslint-plugin-react-hooks` — Rules of Hooks enforcement
- `globals` — Browser/Node/Jest global definitions

### Closes #39

## Test plan
- [x] `yarn lint` passes with `--max-warnings 0`
- [x] `yarn test:frontend --ci --watchAll=false` — 22 tests pass
- [x] `yarn test:backend --ci` — 85 tests pass
- [x] `yarn build:react` succeeds